### PR TITLE
Kokkos::Experimental::Half for SYCL 

### DIFF
--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -61,9 +61,10 @@
 // operator paths should be used.
 // For CUDA, let the compiler conditionally select when device ops are used
 // For SYCL, Sycl/Kokkos_Sycl_Half_Impl_type.hpp defines
-// __SYCL_ONLU_USE_FPW_DEVICE_OPS__
-#define __FPW_USE_DEVICE_OPS__ \
-  defined(__CUDA_ARCH__) || defined(__SYCL_ONLY_USE_FPW_DEVICE_OPS__)
+// __SYCL_ONLY_USE_FPW_DEVICE_OPS__
+#if defined(__CUDA_ARCH__) || defined(__SYCL_ONLY_USE_FPW_DEVICE_OPS__)
+#define __FPW_USE_DEVICE_OPS__
+#endif
 
 /************************* BEGIN forward declarations *************************/
 namespace Kokkos {
@@ -262,7 +263,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_INLINE_FUNCTION
   floating_point_wrapper(const volatile floating_point_wrapper& rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#if defined(__FPW_USE_DEVICE_OPS__)
     val = rhs.val;
 #else
     const volatile fixed_width_integer_type* rv_ptr =
@@ -357,7 +358,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   floating_point_wrapper operator+() const {
     floating_point_wrapper tmp = *this;
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     tmp.val = +tmp.val;
 #else
     tmp.val   = cast_to_wrapper(+cast_from_wrapper<float>(tmp), val).val;
@@ -368,7 +369,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   floating_point_wrapper operator-() const {
     floating_point_wrapper tmp = *this;
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     tmp.val = -tmp.val;
 #else
     tmp.val   = cast_to_wrapper(-cast_from_wrapper<float>(tmp), val).val;
@@ -379,7 +380,7 @@ class alignas(FloatType) floating_point_wrapper {
   // Prefix operators
   KOKKOS_FUNCTION
   floating_point_wrapper& operator++() {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val + impl_type(1.0F);  // cuda has no operator++ for __nv_bfloat
 #else
     float tmp = cast_from_wrapper<float>(*this);
@@ -391,7 +392,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   floating_point_wrapper& operator--() {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val - impl_type(1.0F);  // cuda has no operator-- for __nv_bfloat
 #else
     float tmp = cast_from_wrapper<float>(*this);
@@ -441,7 +442,7 @@ class alignas(FloatType) floating_point_wrapper {
   // Compound operators
   KOKKOS_FUNCTION
   floating_point_wrapper& operator+=(floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val + rhs.val;  // cuda has no operator+= for __nv_bfloat
 #else
     val = cast_to_wrapper(
@@ -486,7 +487,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   floating_point_wrapper& operator-=(floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val - rhs.val;  // cuda has no operator-= for __nv_bfloat
 #else
     val = cast_to_wrapper(
@@ -531,7 +532,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   floating_point_wrapper& operator*=(floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val * rhs.val;  // cuda has no operator*= for __nv_bfloat
 #else
     val = cast_to_wrapper(
@@ -576,7 +577,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   floating_point_wrapper& operator/=(floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     val = val / rhs.val;  // cuda has no operator/= for __nv_bfloat
 #else
     val = cast_to_wrapper(
@@ -623,7 +624,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   friend floating_point_wrapper operator+(floating_point_wrapper lhs,
                                           floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     lhs += rhs;
 #else
     lhs.val = cast_to_wrapper(
@@ -652,7 +653,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   friend floating_point_wrapper operator-(floating_point_wrapper lhs,
                                           floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     lhs -= rhs;
 #else
     lhs.val = cast_to_wrapper(
@@ -681,7 +682,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   friend floating_point_wrapper operator*(floating_point_wrapper lhs,
                                           floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     lhs *= rhs;
 #else
     lhs.val = cast_to_wrapper(
@@ -710,7 +711,7 @@ class alignas(FloatType) floating_point_wrapper {
   KOKKOS_FUNCTION
   friend floating_point_wrapper operator/(floating_point_wrapper lhs,
                                           floating_point_wrapper rhs) {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     lhs /= rhs;
 #else
     lhs.val = cast_to_wrapper(
@@ -739,7 +740,7 @@ class alignas(FloatType) floating_point_wrapper {
   // Logical operators
   KOKKOS_FUNCTION
   bool operator!() const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(!val);
 #else
     return !cast_from_wrapper<float>(*this);
@@ -749,7 +750,7 @@ class alignas(FloatType) floating_point_wrapper {
   // NOTE: Loses short-circuit evaluation
   KOKKOS_FUNCTION
   bool operator&&(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val && rhs.val);
 #else
     return cast_from_wrapper<float>(*this) && cast_from_wrapper<float>(rhs);
@@ -759,7 +760,7 @@ class alignas(FloatType) floating_point_wrapper {
   // NOTE: Loses short-circuit evaluation
   KOKKOS_FUNCTION
   bool operator||(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val || rhs.val);
 #else
     return cast_from_wrapper<float>(*this) || cast_from_wrapper<float>(rhs);
@@ -769,7 +770,7 @@ class alignas(FloatType) floating_point_wrapper {
   // Comparison operators
   KOKKOS_FUNCTION
   bool operator==(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val == rhs.val);
 #else
     return cast_from_wrapper<float>(*this) == cast_from_wrapper<float>(rhs);
@@ -778,7 +779,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   bool operator!=(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val != rhs.val);
 #else
     return cast_from_wrapper<float>(*this) != cast_from_wrapper<float>(rhs);
@@ -787,7 +788,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   bool operator<(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val < rhs.val);
 #else
     return cast_from_wrapper<float>(*this) < cast_from_wrapper<float>(rhs);
@@ -796,7 +797,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   bool operator>(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val > rhs.val);
 #else
     return cast_from_wrapper<float>(*this) > cast_from_wrapper<float>(rhs);
@@ -805,7 +806,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   bool operator<=(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val <= rhs.val);
 #else
     return cast_from_wrapper<float>(*this) <= cast_from_wrapper<float>(rhs);
@@ -814,7 +815,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_FUNCTION
   bool operator>=(floating_point_wrapper rhs) const {
-#if __FPW_USE_DEVICE_OPS__
+#ifdef __FPW_USE_DEVICE_OPS__
     return static_cast<bool>(val >= rhs.val);
 #else
     return cast_from_wrapper<float>(*this) >= cast_from_wrapper<float>(rhs);

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -53,6 +53,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 ///////// Include special backend specific headers and impl types here /////////
 #include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
+#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
@@ -263,7 +264,7 @@ class alignas(FloatType) floating_point_wrapper {
 
   KOKKOS_INLINE_FUNCTION
   floating_point_wrapper(const volatile floating_point_wrapper& rhs) {
-#if defined(__FPW_USE_DEVICE_OPS__)
+#if defined(__FPW_USE_DEVICE_OPS__) && !defined(KOKKOS_ENABLE_SYCL)
     val = rhs.val;
 #else
     const volatile fixed_width_integer_type* rv_ptr =
@@ -325,7 +326,7 @@ class alignas(FloatType) floating_point_wrapper {
    * conversion constructors.
    */
   KOKKOS_FUNCTION
-  floating_point_wrapper(impl_type rhs) : val(rhs) {}
+  constexpr floating_point_wrapper(impl_type rhs) : val(rhs) {}
   KOKKOS_FUNCTION
   floating_point_wrapper(float rhs) : val(cast_to_wrapper(rhs, val).val) {}
   KOKKOS_FUNCTION
@@ -916,6 +917,7 @@ cast_from_wrapper(const Kokkos::Experimental::bhalf_t& x) {
 ////////////////////////////////////////////////////////////////////////////////
 ////// Include special backend specific cast routines and identities here //////
 #include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>
+#include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
 ////////////////////////////////////////////////////////////////////////////////
 
 // Potentially include special compiler specific versions here

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -1,0 +1,158 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.5
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_SYCL_HALF_HPP_
+#define KOKKOS_SYCL_HALF_HPP_
+
+#ifdef KOKKOS_SYCL_IMPL_HALF_TYPE_DEFINED
+
+#include <Kokkos_NumericTraits.hpp>  // reduction_identity
+
+namespace Kokkos {
+namespace Experimental {
+
+/************************** half conversions **********************************/
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(half_t val) { return val; }
+
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(float val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(double val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(short val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(unsigned short val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(int val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(unsigned int val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(long long val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(unsigned long long val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(long val) { return half_t::impl_type(val); }
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(unsigned long val) { return half_t::impl_type(val); }
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, float>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, double>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, short>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned short>::value, T>
+    cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, int>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, unsigned int>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long long>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long long>::value, T>
+    cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same<T, long>::value, T>
+cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same<T, unsigned long>::value, T>
+    cast_from_half(half_t val) {
+  return half_t::impl_type(val);
+}
+}  // namespace Experimental
+
+template <>
+struct reduction_identity<Kokkos::Experimental::half_t> {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
+  sum() noexcept {
+    return Kokkos::Experimental::half_t::impl_type(0.0F);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
+  prod() noexcept {
+    return Kokkos::Experimental::half_t::impl_type(1.0F);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
+  max() noexcept {
+    return std::numeric_limits<
+        Kokkos::Experimental::half_t::impl_type>::lowest();
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static Kokkos::Experimental::half_t
+  min() noexcept {
+    return std::numeric_limits<Kokkos::Experimental::half_t::impl_type>::max();
+  }
+};
+
+}  // namespace Kokkos
+#endif  // KOKKOS_SYCL_IMPL_HALF_TYPE_DEFINED
+#endif

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -1,0 +1,68 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.5
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef KOKKOS_SYCL_HALF_IMPL_TYPE_HPP_
+#define KOKKOS_SYCL_HALF_IMPL_TYPE_HPP_
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_SYCL
+
+#include <CL/sycl.hpp>
+
+#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
+// Make sure no one else tries to define half_t
+#define KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_SYCL_IMPL_HALF_TYPE_DEFINED
+#define __SYCL_ONLY_USE_FPW_DEVICE_OPS__
+
+namespace Kokkos {
+namespace Impl {
+struct half_impl_t {
+  using type = sycl::half;
+};
+}  // namespace Impl
+}  // namespace Kokkos
+#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
+#endif  // KOKKOS_ENABLE_SYCL
+#endif


### PR DESCRIPTION
This corresponds to the current version of https://github.com/kokkos/kokkos/pull/4654 with a somewhat better history.

The first commit just fixes some compiler warnings I was getting and the second one actually adds `SYCL` specific changes. Note that this also includes some changes to  `core/src/Kokkos_Half.hpp`. Namely, constructing from a volatile object doesn't work in a straightforward way so we fall back to the CUDA+Host path and I also decided to try to return the correct type from `reduction_identity` which requires me to have a `constexpr` conversion operator form `impl_type`. I don't feel very strongly about this last point in case this doesn't work for `Cuda` or we don't backends to differ in the return type.

